### PR TITLE
Use !important to prevent VueDragResize messing up TOP/LEFT

### DIFF
--- a/src/components/VueResize.vue
+++ b/src/components/VueResize.vue
@@ -40,10 +40,6 @@ export default
     {
       onResize (newRect) {
         this.$store.commit('panes/setResizing', true)
-        // without NextTick() Vue-Drag-Resize overrides our setting
-        this.$nextTick(() => {
-          this.$refs.vdr.style.top = '0'
-        })
         this.$emit('resize', newRect)
       },
       onStopResize () {
@@ -60,6 +56,8 @@ export default
     position: relative;
     max-width: 100vw;
     max-height: calc(100vh - 6em); /* exclude header */
+    top: 0 !important;
+    left: 0 !important;
 
     &::before
     {


### PR DESCRIPTION
VueDragResize insists on setting non-zero TOP and/or LEFT as an inline style. We do not want this behavior - so the naive solution was to use `$nextTick` and override the value in the inline style. However, sometimes this does not work and is not robust enough. A more simple solution is to simply put `!important` on our custom CSS style.