### PR TITLE
Autoclosing panels with no tabs

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -77,7 +77,8 @@
                       </td>
                       <td>
                         <label for="panel_row_0_column_1">
-                          <input type="checkbox" id="panel_row_0_column_1" name="panel_row_0_column_1" v-model="panels_top" value="1"/>
+                          <input v-if="rowFirst" type="checkbox" id="panel_row_0_column_1" name="panel_row_0_column_1" v-model="panels_top" value="1"/>
+                          <input v-else type="checkbox" id="panel_row_1_column_0" name="panel_row_1_column_0" v-model="panels_bottom" value="2"/>
                         </label>
                       </td>
                     </tr>
@@ -86,7 +87,8 @@
                       </th>
                       <td>
                         <label for="panel_row_1_column_0">
-                          <input type="checkbox" id="panel_row_1_column_0" name="panel_row_1_column_0" v-model="panels_bottom" value="2"/>
+                          <input v-if="rowFirst" type="checkbox" id="panel_row_1_column_0" name="panel_row_1_column_0" v-model="panels_bottom" value="2"/>
+                          <input v-else type="checkbox" id="panel_row_0_column_1" name="panel_row_0_column_1" v-model="panels_top" value="1"/>
                         </label>
                       </td>
                       <td>
@@ -197,6 +199,9 @@ export default
         let active = this.$store.state.panes.activeMobileTab
         return this.allTabs.find(item => item.id === active)
       },
+      rowFirst () {
+        return this.$store.state.panes.disposition.type === 'rowfirst'
+      },
     },
   watch:
     {
@@ -222,7 +227,7 @@ export default
           // a new panel was created
           this.optionsMenuOpen = false
           let panel = oldVal.length ? (oldVal[0] === newVal[0] ? newVal[1] : newVal[0]) : newVal[0]
-          this.$store.state.panes.items[panel].showapps = true
+          if (this.$store.state.panes.items[panel].tabs.length === 0) this.$store.state.panes.items[panel].showapps = true
         }
       },
       clickMenuMobile () {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -72,12 +72,12 @@
                       </th>
                       <td>
                         <label for="panel_row_0_column_0">
-                          <input type="checkbox" id="panel_row_0_column_0" name="panel_row_0_column_0" v-model="panels_top" value="0" @click="updPanels"/>
+                          <input type="checkbox" id="panel_row_0_column_0" name="panel_row_0_column_0" v-model="panels_top" value="0"/>
                         </label>
                       </td>
                       <td>
                         <label for="panel_row_0_column_1">
-                          <input type="checkbox" id="panel_row_0_column_1" name="panel_row_0_column_1" v-model="panels_top" value="1" @click="updPanels"/>
+                          <input type="checkbox" id="panel_row_0_column_1" name="panel_row_0_column_1" v-model="panels_top" value="1"/>
                         </label>
                       </td>
                     </tr>
@@ -86,12 +86,12 @@
                       </th>
                       <td>
                         <label for="panel_row_1_column_0">
-                          <input type="checkbox" id="panel_row_1_column_0" name="panel_row_1_column_0" v-model="panels_bottom" value="2" @click="updPanels"/>
+                          <input type="checkbox" id="panel_row_1_column_0" name="panel_row_1_column_0" v-model="panels_bottom" value="2"/>
                         </label>
                       </td>
                       <td>
                         <label for="panel_row_1_column_1">
-                          <input type="checkbox" id="panel_row_1_column_1" name="panel_row_1_column_1" v-model="panels_bottom" value="3" @click="updPanels"/>
+                          <input type="checkbox" id="panel_row_1_column_1" name="panel_row_1_column_1" v-model="panels_bottom" value="3"/>
                         </label>
                       </td>
                     </tr>
@@ -214,14 +214,16 @@ export default
       onCloseMobile () {
         this.mobileMenuOpen = false
       },
-      updPanels () {
+      updPanels (newVal, oldVal) {
         const top = this.panels_top.map(item => Number(item)).sort()
         const bottom = this.panels_bottom.map(item => Number(item)).sort()
         this.$store.commit('panes/changeDisposition', [top, bottom])
-        /*
-          (top.length > 0 && bottom.length > 0) ? [top, bottom]
-            : top.length > 0 ? [top] : bottom.length > 0 ? [bottom] : []);
-            */
+        if (newVal.length > oldVal.length) {
+          // a new panel was created
+          this.optionsMenuOpen = false
+          let panel = oldVal.length ? (oldVal[0] === newVal[0] ? newVal[1] : newVal[0]) : newVal[0]
+          this.$store.state.panes.items[panel].showapps = true
+        }
       },
       clickMenuMobile () {
         this.mobileMenuOpen = !this.mobileMenuOpen

--- a/src/store/panes.js
+++ b/src/store/panes.js
@@ -19,7 +19,7 @@ const state = {
 
   disposition:
     {
-      type: 'rowfirst',
+      type: 'colfirst',
       itempos: [ [ 0, 1 ], [ 2 ] ],
     },
   items:

--- a/src/store/panes.js
+++ b/src/store/panes.js
@@ -64,116 +64,6 @@ const state = {
           ],
       },
     ],
-
-  /*
-  disposition:
-  {
-    type: 'rowfirst',
-    itempos: [ [ 0, 1 ], [ 2, 3 ] ],
-  },
-  items:
-  [
-    {
-      active: 0,
-      showapps: false,
-      tabs:
-      [
-        {
-          id: 0,
-          title: 'Temp1',
-          src: 'https://www.example.com/',
-        },
-      ],
-    },
-    {
-      active: 1,
-      showapps: false,
-      tabs:
-      [
-        {
-          id: 1,
-          title: 'Temp2',
-          src: 'https://www.example.com/',
-        },
-      ],
-    },
-    {
-      active: 2,
-      showapps: false,
-      tabs:
-      [
-        {
-          id: 2,
-          title: 'Temp3',
-          src: 'https://www.example.com/',
-        },
-      ],
-    },
-    {
-      active: 3,
-      showapps: false,
-      tabs:
-      [
-        {
-          id: 3,
-          title: 'Temp4',
-          src: 'https://www.example.com/',
-        },
-      ],
-    },
-  ],
-  */
-  /* items:
-  [
-    {
-      active: 0,
-      showapps: false,
-      tabs:
-      [
-        {
-          id: 0,
-          title: 'Messaging',
-          src: 'https://beta.rustbucket.io/messaging/',
-        },
-      ],
-    },
-    {
-      active: 1,
-      showapps: false,
-      tabs:
-      [
-        {
-          id: 1,
-          title: 'Temp4',
-          src: 'https://www.example.com/',
-        },
-        {
-          id: 2,
-          title: 'Temp5',
-          src: 'https://www.example.com/',
-        },
-        {
-          id: 3,
-          title: 'Temp6',
-          src: 'https://www.example.com/',
-        },
-      ],
-    },
-    {
-      active: 0,
-      showapps: true,
-      tabs:
-      [
-      ],
-    },
-    {
-      active: 0,
-      showapps: false,
-      tabs:
-      [
-      ],
-    },
-  ], */
 }
 
 // Below would be the default case : no panels to start with.
@@ -274,8 +164,7 @@ const mutations =
       }
       return true
     })
-    console.log('active')
-    console.log(pane.active)
+    console.log('active = ' + pane.active)
     if (itemIndexToDel !== -1) {
       const allTabs = state.items.reduce((acc, panel) => {
         return acc.concat(panel.tabs)
@@ -297,6 +186,16 @@ const mutations =
         if (itemIndex) state.activeMobileTab = allTabs[itemIndex - 1].id
         else if (allTabs.length > 1) state.activeMobileTab = allTabs[itemIndex + 1].id
         else state.activeMobileTab = null
+      }
+      if (tabItems.length === 0) {
+        // hide the panel - no more tabs
+        const paneID = state.items.indexOf(pane)
+        const idx = state.disposition.itempos[0].indexOf(paneID)
+        if (idx !== -1) state.disposition.itempos[0].splice(idx, 1)
+        else {
+          const idx = state.disposition.itempos[1].indexOf(paneID)
+          if (idx !== -1) state.disposition.itempos[1].splice(idx, 1)
+        }
       }
     }
   },


### PR DESCRIPTION
1) When you select to show a new panel in the sidebar, the following must happen:
   1) Close the panel sidebar
   2) Open the app selector in fullscreen
   3) After selecting an app, open it in the newly selected panel
   Closing panels must stay the same (just as now I mean)
2) When the last tab of a panel is closed, the panel the tab was in must be closed too.
3) In panes.js, line 22, we have a variable in the state conts called "type". Now it has the value "rowfirst". When it has the value "colfirst" it must split columns, and not rows.